### PR TITLE
[REFACTOR] 전체 수면 기록 조회 및 수면 목표 설정 api 마이그레이션

### DIFF
--- a/src/main/java/com/project/sleep/domain/application/dto/request/SetSleepGoalRequest.java
+++ b/src/main/java/com/project/sleep/domain/application/dto/request/SetSleepGoalRequest.java
@@ -1,0 +1,11 @@
+package com.project.sleep.domain.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalTime;
+
+public record SetSleepGoalRequest(
+        @NotNull(message = "목표 취침 시각은 필수입니다.") LocalTime goalBedTime,
+        @NotNull(message = "목표 기상 시각은 필수입니다.") LocalTime goalWakeTime,
+        @NotNull(message = "목표 총 수면 시간은 필수입니다.") Integer goalTotalSleepTime
+) {}

--- a/src/main/java/com/project/sleep/domain/application/dto/request/SleepGoalRequest.java
+++ b/src/main/java/com/project/sleep/domain/application/dto/request/SleepGoalRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalTime;
 
-public record SetSleepGoalRequest(
+public record SleepGoalRequest(
         @NotNull(message = "목표 취침 시각은 필수입니다.") LocalTime goalBedTime,
         @NotNull(message = "목표 기상 시각은 필수입니다.") LocalTime goalWakeTime,
         @NotNull(message = "목표 총 수면 시간은 필수입니다.") Integer goalTotalSleepTime

--- a/src/main/java/com/project/sleep/domain/application/dto/response/SleepGoalResponse.java
+++ b/src/main/java/com/project/sleep/domain/application/dto/response/SleepGoalResponse.java
@@ -1,0 +1,21 @@
+package com.project.sleep.domain.application.dto.response;
+
+import com.project.sleep.domain.domain.entity.SleepGoal;
+import lombok.Builder;
+
+import java.time.LocalTime;
+
+@Builder
+public record SleepGoalResponse(
+        LocalTime goalBedTime,
+        LocalTime goalWakeTime,
+        Integer goalTotalSleepTime
+) {
+    public static SleepGoalResponse from(SleepGoal entity) {
+        return SleepGoalResponse.builder()
+                .goalBedTime(entity.getGoalBedTime())
+                .goalWakeTime(entity.getGoalWakeTime())
+                .goalTotalSleepTime(entity.getGoalTotalSleepTime())
+                .build();
+    }
+}

--- a/src/main/java/com/project/sleep/domain/application/dto/response/SleepPatternsResponse.java
+++ b/src/main/java/com/project/sleep/domain/application/dto/response/SleepPatternsResponse.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import java.time.LocalDate;
 
 @Builder
-public record GetSleepPatternsResponse(
+public record SleepPatternsResponse(
         LocalDate date,
         int score,
         int totalSleepTime

--- a/src/main/java/com/project/sleep/domain/application/dto/response/TotalSleepRecordResponse.java
+++ b/src/main/java/com/project/sleep/domain/application/dto/response/TotalSleepRecordResponse.java
@@ -1,0 +1,21 @@
+package com.project.sleep.domain.application.dto.response;
+
+import com.project.sleep.domain.domain.entity.TotalSleepRecord;
+import lombok.Builder;
+
+import java.time.LocalTime;
+
+@Builder
+public record TotalSleepRecordResponse(
+        Integer avgScore,
+        Integer avgSleepTime,
+        LocalTime avgBedTime
+) {
+    public static TotalSleepRecordResponse from(TotalSleepRecord entity) {
+        return TotalSleepRecordResponse.builder()
+                .avgScore(entity.getAvgScore())
+                .avgBedTime(entity.getAvgBedTime())
+                .avgSleepTime(entity.getAvgSleepTime())
+                .build();
+    }
+}

--- a/src/main/java/com/project/sleep/domain/application/usecase/GetSleepGoalUseCase.java
+++ b/src/main/java/com/project/sleep/domain/application/usecase/GetSleepGoalUseCase.java
@@ -13,7 +13,7 @@ public class GetSleepGoalUseCase {
     private final SleepGoalService sleepGoalService;
 
     public SleepGoalResponse execute(Long userNo) {
-        SleepGoal entity = sleepGoalService.findByUserNo(userNo);
+        SleepGoal entity = sleepGoalService.findById(userNo);
         return SleepGoalResponse.from(entity);
     }
 }

--- a/src/main/java/com/project/sleep/domain/application/usecase/GetSleepGoalUseCase.java
+++ b/src/main/java/com/project/sleep/domain/application/usecase/GetSleepGoalUseCase.java
@@ -1,0 +1,19 @@
+package com.project.sleep.domain.application.usecase;
+
+import com.project.sleep.domain.application.dto.response.SleepGoalResponse;
+import com.project.sleep.domain.domain.entity.SleepGoal;
+import com.project.sleep.domain.domain.service.SleepGoalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetSleepGoalUseCase {
+
+    private final SleepGoalService sleepGoalService;
+
+    public SleepGoalResponse execute(Long userNo) {
+        SleepGoal entity = sleepGoalService.findByUserNo(userNo);
+        return SleepGoalResponse.from(entity);
+    }
+}

--- a/src/main/java/com/project/sleep/domain/application/usecase/GetSleepPatternsUseCase.java
+++ b/src/main/java/com/project/sleep/domain/application/usecase/GetSleepPatternsUseCase.java
@@ -1,6 +1,6 @@
 package com.project.sleep.domain.application.usecase;
 
-import com.project.sleep.domain.application.dto.response.GetSleepPatternsResponse;
+import com.project.sleep.domain.application.dto.response.SleepPatternsResponse;
 import com.project.sleep.domain.domain.entity.DailySleepRecord;
 import com.project.sleep.domain.domain.service.SleepPatternsService;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,7 @@ public class GetSleepPatternsUseCase {
 
     private final SleepPatternsService getSleepPatternsService;
 
-    public List<GetSleepPatternsResponse> getSleepPatterns(Long userNo, LocalDate startDate, LocalDate endDate) {
+    public List<SleepPatternsResponse> getSleepPatterns(Long userNo, LocalDate startDate, LocalDate endDate) {
 
         // 비즈니스 규칙: startDate는 endDate보다 이후일 수 없음
         if (startDate.isAfter(endDate)) {
@@ -26,7 +26,7 @@ public class GetSleepPatternsUseCase {
 
         // 빌더, toList 수정
         return sleepRecords.stream()
-                .map(record -> GetSleepPatternsResponse.builder()
+                .map(record -> SleepPatternsResponse.builder()
                         .date(record.getSleepDate())
                         .score(record.getScore())
                         .totalSleepTime(record.getTotalSleepTime())

--- a/src/main/java/com/project/sleep/domain/application/usecase/GetTotalSleepRecordUseCase.java
+++ b/src/main/java/com/project/sleep/domain/application/usecase/GetTotalSleepRecordUseCase.java
@@ -13,7 +13,7 @@ public class GetTotalSleepRecordUseCase {
     private final TotalSleepRecordService totalSleepRecordService;
 
     public TotalSleepRecordResponse execute(Long userNo) {
-        TotalSleepRecord entity = totalSleepRecordService.findByUserNo(userNo);
+        TotalSleepRecord entity = totalSleepRecordService.findById(userNo);
         return TotalSleepRecordResponse.from(entity);
     }
 }

--- a/src/main/java/com/project/sleep/domain/application/usecase/GetTotalSleepRecordUseCase.java
+++ b/src/main/java/com/project/sleep/domain/application/usecase/GetTotalSleepRecordUseCase.java
@@ -1,0 +1,19 @@
+package com.project.sleep.domain.application.usecase;
+
+import com.project.sleep.domain.application.dto.response.TotalSleepRecordResponse;
+import com.project.sleep.domain.domain.entity.TotalSleepRecord;
+import com.project.sleep.domain.domain.service.TotalSleepRecordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetTotalSleepRecordUseCase {
+
+    private final TotalSleepRecordService totalSleepRecordService;
+
+    public TotalSleepRecordResponse execute(Long userNo) {
+        TotalSleepRecord entity = totalSleepRecordService.findByUserNo(userNo);
+        return TotalSleepRecordResponse.from(entity);
+    }
+}

--- a/src/main/java/com/project/sleep/domain/application/usecase/SetSleepGoalUseCase.java
+++ b/src/main/java/com/project/sleep/domain/application/usecase/SetSleepGoalUseCase.java
@@ -1,6 +1,6 @@
 package com.project.sleep.domain.application.usecase;
 
-import com.project.sleep.domain.application.dto.request.SetSleepGoalRequest;
+import com.project.sleep.domain.application.dto.request.SleepGoalRequest;
 import com.project.sleep.domain.domain.service.SleepGoalService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,7 +11,7 @@ public class SetSleepGoalUseCase {
 
     private final SleepGoalService sleepGoalService;
 
-    public void execute(Long userNo, SetSleepGoalRequest request) {
+    public void execute(Long userNo, SleepGoalRequest request) {
         sleepGoalService.upsert(userNo, request);
     }
 }

--- a/src/main/java/com/project/sleep/domain/application/usecase/SetSleepGoalUseCase.java
+++ b/src/main/java/com/project/sleep/domain/application/usecase/SetSleepGoalUseCase.java
@@ -1,0 +1,17 @@
+package com.project.sleep.domain.application.usecase;
+
+import com.project.sleep.domain.application.dto.request.SetSleepGoalRequest;
+import com.project.sleep.domain.domain.service.SleepGoalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SetSleepGoalUseCase {
+
+    private final SleepGoalService sleepGoalService;
+
+    public void execute(Long userNo, SetSleepGoalRequest request) {
+        sleepGoalService.upsert(userNo, request);
+    }
+}

--- a/src/main/java/com/project/sleep/domain/domain/entity/DailyReport.java
+++ b/src/main/java/com/project/sleep/domain/domain/entity/DailyReport.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class DailyReport {
 
     @Id
-    private Long dailyReportNo;
+    private String dailyReportNo;
 
     @Field(value = "sleep_date")
     private LocalDateTime sleepDate;

--- a/src/main/java/com/project/sleep/domain/domain/entity/SleepGoal.java
+++ b/src/main/java/com/project/sleep/domain/domain/entity/SleepGoal.java
@@ -18,9 +18,6 @@ import java.time.LocalTime;
 public class SleepGoal {
 
     @Id
-    @Field(name = "goal_no")
-    private String goalNo;
-
     @Field(name = "user_no")
     private Long userNo;
 

--- a/src/main/java/com/project/sleep/domain/domain/entity/SleepGoal.java
+++ b/src/main/java/com/project/sleep/domain/domain/entity/SleepGoal.java
@@ -1,0 +1,41 @@
+package com.project.sleep.domain.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@Document(collection = "sleep_goal")
+@AllArgsConstructor
+@NoArgsConstructor
+public class SleepGoal {
+
+    @Id
+    @Field(name = "goal_no")
+    private String goalNo;
+
+    @Field(name = "user_no")
+    private Long userNo;
+
+    @Field(name = "goal_bed_time")
+    private LocalTime goalBedTime;
+
+    @Field(name = "goal_wake_time")
+    private LocalTime goalWakeTime;
+
+    @Field(name = "goal_total_sleep_time")
+    private Integer goalTotalSleepTime;
+
+    public void update(LocalTime goalBedTime, LocalTime goalWakeTime, Integer goalTotalSleepTime) {
+        this.goalBedTime = goalBedTime;
+        this.goalWakeTime = goalWakeTime;
+        this.goalTotalSleepTime = goalTotalSleepTime;
+    }
+}

--- a/src/main/java/com/project/sleep/domain/domain/entity/TotalSleepRecord.java
+++ b/src/main/java/com/project/sleep/domain/domain/entity/TotalSleepRecord.java
@@ -18,8 +18,8 @@ import java.time.LocalTime;
 public class TotalSleepRecord {
 
     @Id
-    @Field(name = "total_sleep_record_no")
-    private String totalSleepRecordNo;
+    @Field(name = "user_no")
+    private Long userNo;
 
     @Field(name = "avg_score")
     private Integer avgScore;
@@ -29,8 +29,5 @@ public class TotalSleepRecord {
 
     @Field(name = "avg_bed_time")
     private LocalTime avgBedTime;
-
-    @Field(name = "user_no")
-    private Long userNo;
 
 }

--- a/src/main/java/com/project/sleep/domain/domain/entity/TotalSleepRecord.java
+++ b/src/main/java/com/project/sleep/domain/domain/entity/TotalSleepRecord.java
@@ -1,0 +1,23 @@
+package com.project.sleep.domain.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+@Builder
+@Document(collection = "total_sleep_record")
+@AllArgsConstructor
+@NoArgsConstructor
+public class TotalSleepRecord {
+
+    @Id
+    @Field(name = "total_sleep_record_no")
+    private String totalSleepRecordNo;
+
+
+}

--- a/src/main/java/com/project/sleep/domain/domain/entity/TotalSleepRecord.java
+++ b/src/main/java/com/project/sleep/domain/domain/entity/TotalSleepRecord.java
@@ -8,6 +8,8 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import java.time.LocalTime;
+
 @Getter
 @Builder
 @Document(collection = "total_sleep_record")
@@ -19,5 +21,16 @@ public class TotalSleepRecord {
     @Field(name = "total_sleep_record_no")
     private String totalSleepRecordNo;
 
+    @Field(name = "avg_score")
+    private Integer avgScore;
+
+    @Field(name = "avg_sleep_time")
+    private Integer avgSleepTime;
+
+    @Field(name = "avg_bed_time")
+    private LocalTime avgBedTime;
+
+    @Field(name = "user_no")
+    private Long userNo;
 
 }

--- a/src/main/java/com/project/sleep/domain/domain/repository/SleepGoalRepository.java
+++ b/src/main/java/com/project/sleep/domain/domain/repository/SleepGoalRepository.java
@@ -1,0 +1,10 @@
+package com.project.sleep.domain.domain.repository;
+
+import com.project.sleep.domain.domain.entity.SleepGoal;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface SleepGoalRepository extends MongoRepository<SleepGoal, String> {
+    Optional<SleepGoal> findByUserNo(Long userNo);
+}

--- a/src/main/java/com/project/sleep/domain/domain/repository/SleepGoalRepository.java
+++ b/src/main/java/com/project/sleep/domain/domain/repository/SleepGoalRepository.java
@@ -3,8 +3,5 @@ package com.project.sleep.domain.domain.repository;
 import com.project.sleep.domain.domain.entity.SleepGoal;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-import java.util.Optional;
-
-public interface SleepGoalRepository extends MongoRepository<SleepGoal, String> {
-    Optional<SleepGoal> findByUserNo(Long userNo);
+public interface SleepGoalRepository extends MongoRepository<SleepGoal, Long> {
 }

--- a/src/main/java/com/project/sleep/domain/domain/repository/TotalSleepRecordRepository.java
+++ b/src/main/java/com/project/sleep/domain/domain/repository/TotalSleepRecordRepository.java
@@ -3,8 +3,5 @@ package com.project.sleep.domain.domain.repository;
 import com.project.sleep.domain.domain.entity.TotalSleepRecord;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-import java.util.Optional;
-
-public interface TotalSleepRecordRepository extends MongoRepository<TotalSleepRecord, String> {
-    Optional<TotalSleepRecord> findByUserNo(Long userNo);
+public interface TotalSleepRecordRepository extends MongoRepository<TotalSleepRecord, Long> {
 }

--- a/src/main/java/com/project/sleep/domain/domain/repository/TotalSleepRecordRepository.java
+++ b/src/main/java/com/project/sleep/domain/domain/repository/TotalSleepRecordRepository.java
@@ -1,0 +1,10 @@
+package com.project.sleep.domain.domain.repository;
+
+import com.project.sleep.domain.domain.entity.TotalSleepRecord;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface TotalSleepRecordRepository extends MongoRepository<TotalSleepRecord, String> {
+    Optional<TotalSleepRecord> findByUserNo(Long userNo);
+}

--- a/src/main/java/com/project/sleep/domain/domain/service/SleepGoalService.java
+++ b/src/main/java/com/project/sleep/domain/domain/service/SleepGoalService.java
@@ -1,0 +1,38 @@
+package com.project.sleep.domain.domain.service;
+
+import com.project.sleep.domain.application.dto.request.SetSleepGoalRequest;
+import com.project.sleep.domain.domain.entity.SleepGoal;
+import com.project.sleep.domain.domain.repository.SleepGoalRepository;
+import com.project.sleep.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.project.sleep.global.exception.code.status.GlobalErrorStatus._NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class SleepGoalService {
+
+    private final SleepGoalRepository sleepGoalRepository;
+
+    public void upsert(Long userNo, SetSleepGoalRequest request) {
+        sleepGoalRepository.findByUserNo(userNo)
+                .map(goal -> {
+                    goal.update(request.goalBedTime(), request.goalWakeTime(), request.goalTotalSleepTime());
+                    return sleepGoalRepository.save(goal);
+                })
+                .orElseGet(() -> sleepGoalRepository.save(
+                        SleepGoal.builder()
+                                .userNo(userNo)
+                                .goalBedTime(request.goalBedTime())
+                                .goalWakeTime(request.goalWakeTime())
+                                .goalTotalSleepTime(request.goalTotalSleepTime())
+                                .build()
+                ));
+    }
+
+    public SleepGoal findByUserNo(Long userNo) {
+        return sleepGoalRepository.findByUserNo(userNo)
+                .orElseThrow(() -> new RestApiException(_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/project/sleep/domain/domain/service/SleepGoalService.java
+++ b/src/main/java/com/project/sleep/domain/domain/service/SleepGoalService.java
@@ -1,6 +1,6 @@
 package com.project.sleep.domain.domain.service;
 
-import com.project.sleep.domain.application.dto.request.SetSleepGoalRequest;
+import com.project.sleep.domain.application.dto.request.SleepGoalRequest;
 import com.project.sleep.domain.domain.entity.SleepGoal;
 import com.project.sleep.domain.domain.repository.SleepGoalRepository;
 import com.project.sleep.global.exception.RestApiException;
@@ -15,7 +15,7 @@ public class SleepGoalService {
 
     private final SleepGoalRepository sleepGoalRepository;
 
-    public void upsert(Long userNo, SetSleepGoalRequest request) {
+    public void upsert(Long userNo, SleepGoalRequest request) {
         sleepGoalRepository.findByUserNo(userNo)
                 .map(goal -> {
                     goal.update(request.goalBedTime(), request.goalWakeTime(), request.goalTotalSleepTime());

--- a/src/main/java/com/project/sleep/domain/domain/service/SleepGoalService.java
+++ b/src/main/java/com/project/sleep/domain/domain/service/SleepGoalService.java
@@ -16,7 +16,7 @@ public class SleepGoalService {
     private final SleepGoalRepository sleepGoalRepository;
 
     public void upsert(Long userNo, SleepGoalRequest request) {
-        sleepGoalRepository.findByUserNo(userNo)
+        sleepGoalRepository.findById(userNo)
                 .map(goal -> {
                     goal.update(request.goalBedTime(), request.goalWakeTime(), request.goalTotalSleepTime());
                     return sleepGoalRepository.save(goal);
@@ -31,8 +31,8 @@ public class SleepGoalService {
                 ));
     }
 
-    public SleepGoal findByUserNo(Long userNo) {
-        return sleepGoalRepository.findByUserNo(userNo)
+    public SleepGoal findById(Long userNo) {
+        return sleepGoalRepository.findById(userNo)
                 .orElseThrow(() -> new RestApiException(_NOT_FOUND));
     }
 }

--- a/src/main/java/com/project/sleep/domain/domain/service/TotalSleepRecordService.java
+++ b/src/main/java/com/project/sleep/domain/domain/service/TotalSleepRecordService.java
@@ -1,0 +1,21 @@
+package com.project.sleep.domain.domain.service;
+
+import com.project.sleep.domain.domain.entity.TotalSleepRecord;
+import com.project.sleep.domain.domain.repository.TotalSleepRecordRepository;
+import com.project.sleep.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.project.sleep.global.exception.code.status.GlobalErrorStatus._NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class TotalSleepRecordService {
+
+    private final TotalSleepRecordRepository totalSleepRecordRepository;
+
+    public TotalSleepRecord findByUserNo(Long userNo) {
+        return totalSleepRecordRepository.findByUserNo(userNo)
+                .orElseThrow(() -> new RestApiException(_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/project/sleep/domain/domain/service/TotalSleepRecordService.java
+++ b/src/main/java/com/project/sleep/domain/domain/service/TotalSleepRecordService.java
@@ -14,8 +14,8 @@ public class TotalSleepRecordService {
 
     private final TotalSleepRecordRepository totalSleepRecordRepository;
 
-    public TotalSleepRecord findByUserNo(Long userNo) {
-        return totalSleepRecordRepository.findByUserNo(userNo)
+    public TotalSleepRecord findById(Long userNo) {
+        return totalSleepRecordRepository.findById(userNo)
                 .orElseThrow(() -> new RestApiException(_NOT_FOUND));
     }
 }

--- a/src/main/java/com/project/sleep/domain/ui/GetSleepGoalController.java
+++ b/src/main/java/com/project/sleep/domain/ui/GetSleepGoalController.java
@@ -1,0 +1,20 @@
+package com.project.sleep.domain.ui;
+
+import com.project.sleep.domain.application.dto.response.SleepGoalResponse;
+import com.project.sleep.domain.application.usecase.GetSleepGoalUseCase;
+import com.project.sleep.domain.ui.spec.GetSleepGoalApiSpec;
+import com.project.sleep.global.common.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GetSleepGoalController implements GetSleepGoalApiSpec {
+
+    private final GetSleepGoalUseCase getSleepGoalUseCase;
+
+    @Override
+    public BaseResponse<SleepGoalResponse> get(Long userNo) {
+        return BaseResponse.onSuccess(getSleepGoalUseCase.execute(userNo));
+    }
+}

--- a/src/main/java/com/project/sleep/domain/ui/GetSleepPatternsController.java
+++ b/src/main/java/com/project/sleep/domain/ui/GetSleepPatternsController.java
@@ -1,13 +1,10 @@
 package com.project.sleep.domain.ui;
 
-import com.project.sleep.domain.application.dto.response.GetSleepPatternsResponse;
+import com.project.sleep.domain.application.dto.response.SleepPatternsResponse;
 import com.project.sleep.domain.application.usecase.GetSleepPatternsUseCase;
 import com.project.sleep.domain.ui.spec.GetSleepPatternsApiSpec;
-import com.project.sleep.global.annotation.CurrentUser;
 import com.project.sleep.global.common.BaseResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
@@ -20,7 +17,7 @@ public class GetSleepPatternsController implements GetSleepPatternsApiSpec {
     private final GetSleepPatternsUseCase getSleepPatternsUseCase;
 
     @Override
-    public BaseResponse<List<GetSleepPatternsResponse>> getSleepPatterns(
+    public BaseResponse<List<SleepPatternsResponse>> getSleepPatterns(
             Long userNo,
             LocalDate startDate,
             LocalDate endDate

--- a/src/main/java/com/project/sleep/domain/ui/GetTotalSleepRecordController.java
+++ b/src/main/java/com/project/sleep/domain/ui/GetTotalSleepRecordController.java
@@ -1,0 +1,22 @@
+package com.project.sleep.domain.ui;
+
+import com.project.sleep.domain.application.dto.response.TotalSleepRecordResponse;
+import com.project.sleep.domain.application.usecase.GetTotalSleepRecordUseCase;
+import com.project.sleep.domain.ui.spec.GetTotalSleepRecordApiSpec;
+import com.project.sleep.global.common.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GetTotalSleepRecordController implements GetTotalSleepRecordApiSpec {
+
+    private final GetTotalSleepRecordUseCase getTotalSleepRecordUseCase;
+
+    @Override
+    public BaseResponse<TotalSleepRecordResponse> get(
+            Long userNo
+    ) {
+        return BaseResponse.onSuccess(getTotalSleepRecordUseCase.execute(userNo));
+    }
+}

--- a/src/main/java/com/project/sleep/domain/ui/SetSleepGoalController.java
+++ b/src/main/java/com/project/sleep/domain/ui/SetSleepGoalController.java
@@ -1,0 +1,23 @@
+package com.project.sleep.domain.ui;
+
+import com.project.sleep.domain.application.dto.request.SetSleepGoalRequest;
+import com.project.sleep.domain.application.usecase.SetSleepGoalUseCase;
+import com.project.sleep.domain.ui.spec.SetSleepGoalApiSpec;
+import com.project.sleep.global.common.BaseResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SetSleepGoalController implements SetSleepGoalApiSpec {
+
+    private final SetSleepGoalUseCase setSleepGoalUseCase;
+
+    @Override
+    public BaseResponse<Void> set(Long userNo, @Valid @RequestBody SetSleepGoalRequest request) {
+        setSleepGoalUseCase.execute(userNo, request);
+        return BaseResponse.onSuccess();
+    }
+}

--- a/src/main/java/com/project/sleep/domain/ui/SetSleepGoalController.java
+++ b/src/main/java/com/project/sleep/domain/ui/SetSleepGoalController.java
@@ -1,6 +1,6 @@
 package com.project.sleep.domain.ui;
 
-import com.project.sleep.domain.application.dto.request.SetSleepGoalRequest;
+import com.project.sleep.domain.application.dto.request.SleepGoalRequest;
 import com.project.sleep.domain.application.usecase.SetSleepGoalUseCase;
 import com.project.sleep.domain.ui.spec.SetSleepGoalApiSpec;
 import com.project.sleep.global.common.BaseResponse;
@@ -16,7 +16,7 @@ public class SetSleepGoalController implements SetSleepGoalApiSpec {
     private final SetSleepGoalUseCase setSleepGoalUseCase;
 
     @Override
-    public BaseResponse<Void> set(Long userNo, @Valid @RequestBody SetSleepGoalRequest request) {
+    public BaseResponse<Void> set(Long userNo, @Valid @RequestBody SleepGoalRequest request) {
         setSleepGoalUseCase.execute(userNo, request);
         return BaseResponse.onSuccess();
     }

--- a/src/main/java/com/project/sleep/domain/ui/SetSleepGoalController.java
+++ b/src/main/java/com/project/sleep/domain/ui/SetSleepGoalController.java
@@ -16,7 +16,10 @@ public class SetSleepGoalController implements SetSleepGoalApiSpec {
     private final SetSleepGoalUseCase setSleepGoalUseCase;
 
     @Override
-    public BaseResponse<Void> set(Long userNo, @Valid @RequestBody SleepGoalRequest request) {
+    public BaseResponse<Void> set(
+            Long userNo,
+            @Valid @RequestBody SleepGoalRequest request
+    ) {
         setSleepGoalUseCase.execute(userNo, request);
         return BaseResponse.onSuccess();
     }

--- a/src/main/java/com/project/sleep/domain/ui/spec/GetSleepGoalApiSpec.java
+++ b/src/main/java/com/project/sleep/domain/ui/spec/GetSleepGoalApiSpec.java
@@ -1,0 +1,24 @@
+package com.project.sleep.domain.ui.spec;
+
+import com.project.sleep.domain.application.dto.response.SleepGoalResponse;
+import com.project.sleep.global.annotation.CurrentUser;
+import com.project.sleep.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "Sleep")
+public interface GetSleepGoalApiSpec {
+
+    @Operation(
+            summary = "목표 수면 시간 조회 API",
+            description = "목표 수면 시간을 조회합니다."
+    )
+    @PostMapping("/api/sleep/goal")
+    BaseResponse<SleepGoalResponse> get(
+            @CurrentUser
+            @Parameter(hidden = true)
+            Long userNo
+    );
+}

--- a/src/main/java/com/project/sleep/domain/ui/spec/GetSleepGoalApiSpec.java
+++ b/src/main/java/com/project/sleep/domain/ui/spec/GetSleepGoalApiSpec.java
@@ -6,6 +6,7 @@ import com.project.sleep.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "Sleep")
@@ -15,7 +16,7 @@ public interface GetSleepGoalApiSpec {
             summary = "목표 수면 시간 조회 API",
             description = "목표 수면 시간을 조회합니다."
     )
-    @PostMapping("/api/sleep/goal")
+    @GetMapping("/api/sleep/goal")
     BaseResponse<SleepGoalResponse> get(
             @CurrentUser
             @Parameter(hidden = true)

--- a/src/main/java/com/project/sleep/domain/ui/spec/GetSleepPatternsApiSpec.java
+++ b/src/main/java/com/project/sleep/domain/ui/spec/GetSleepPatternsApiSpec.java
@@ -1,6 +1,6 @@
 package com.project.sleep.domain.ui.spec;
 
-import com.project.sleep.domain.application.dto.response.GetSleepPatternsResponse;
+import com.project.sleep.domain.application.dto.response.SleepPatternsResponse;
 import com.project.sleep.global.annotation.CurrentUser;
 import com.project.sleep.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,7 +21,7 @@ public interface GetSleepPatternsApiSpec {
             description = "사용자의 특정 기간(startDate, endDate)에 해당하는 일별 수면 데이터(날짜, 점수, 총 수면 시간) 리스트를 조회합니다."
     )
     @GetMapping("/api/sleep/patterns")
-    BaseResponse<List<GetSleepPatternsResponse>> getSleepPatterns(
+    BaseResponse<List<SleepPatternsResponse>> getSleepPatterns(
             @Parameter(hidden = true) // Swagger UI에서는 숨김 처리
             @CurrentUser Long userNo,
 

--- a/src/main/java/com/project/sleep/domain/ui/spec/GetTotalSleepRecordApiSpec.java
+++ b/src/main/java/com/project/sleep/domain/ui/spec/GetTotalSleepRecordApiSpec.java
@@ -6,7 +6,7 @@ import com.project.sleep.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Tag(name = "Sleep")
 public interface GetTotalSleepRecordApiSpec {
@@ -15,7 +15,7 @@ public interface GetTotalSleepRecordApiSpec {
             summary = "누적 수면 기록 조회 API",
             description = "누적 수면 기록(평균 수면 시간, 평균 수면 점수, 평균 취침 시각)을 조회합니다."
     )
-    @PostMapping("/api/sleep/total")
+    @GetMapping("/api/sleep/total")
     BaseResponse<TotalSleepRecordResponse> get(
             @CurrentUser
             @Parameter(hidden = true)

--- a/src/main/java/com/project/sleep/domain/ui/spec/GetTotalSleepRecordApiSpec.java
+++ b/src/main/java/com/project/sleep/domain/ui/spec/GetTotalSleepRecordApiSpec.java
@@ -1,0 +1,24 @@
+package com.project.sleep.domain.ui.spec;
+
+import com.project.sleep.domain.application.dto.response.TotalSleepRecordResponse;
+import com.project.sleep.global.annotation.CurrentUser;
+import com.project.sleep.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "Sleep")
+public interface GetTotalSleepRecordApiSpec {
+
+    @Operation(
+            summary = "누적 수면 기록 조회 API",
+            description = "누적 수면 기록(평균 수면 시간, 평균 수면 점수, 평균 취침 시각)을 조회합니다."
+    )
+    @PostMapping("/api/sleep/total")
+    BaseResponse<TotalSleepRecordResponse> get(
+            @CurrentUser
+            @Parameter(hidden = true)
+            Long userNo
+    );
+}

--- a/src/main/java/com/project/sleep/domain/ui/spec/SetSleepGoalApiSpec.java
+++ b/src/main/java/com/project/sleep/domain/ui/spec/SetSleepGoalApiSpec.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "Sleep")

--- a/src/main/java/com/project/sleep/domain/ui/spec/SetSleepGoalApiSpec.java
+++ b/src/main/java/com/project/sleep/domain/ui/spec/SetSleepGoalApiSpec.java
@@ -1,13 +1,12 @@
 package com.project.sleep.domain.ui.spec;
 
-import com.project.sleep.domain.application.dto.request.SetSleepGoalRequest;
+import com.project.sleep.domain.application.dto.request.SleepGoalRequest;
 import com.project.sleep.global.annotation.CurrentUser;
 import com.project.sleep.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "Sleep")
@@ -26,6 +25,6 @@ public interface SetSleepGoalApiSpec {
                     description = "목표 수면 시간 설정값",
                     required = true
             )
-            SetSleepGoalRequest request
+            SleepGoalRequest request
     );
 }

--- a/src/main/java/com/project/sleep/domain/ui/spec/SetSleepGoalApiSpec.java
+++ b/src/main/java/com/project/sleep/domain/ui/spec/SetSleepGoalApiSpec.java
@@ -1,0 +1,31 @@
+package com.project.sleep.domain.ui.spec;
+
+import com.project.sleep.domain.application.dto.request.SetSleepGoalRequest;
+import com.project.sleep.global.annotation.CurrentUser;
+import com.project.sleep.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "Sleep")
+public interface SetSleepGoalApiSpec {
+
+    @Operation(
+            summary = "목표 수면 시간 설정 API",
+            description = "목표 수면 시간을 설정합니다."
+    )
+    @PostMapping("/api/sleep/goal")
+    BaseResponse<Void> set(
+            @CurrentUser
+            @Parameter(hidden = true)
+            Long userNo,
+            @RequestBody(
+                    description = "목표 수면 시간 설정값",
+                    required = true
+            )
+            SetSleepGoalRequest request
+    );
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 18080
 
 spring:
   data:

--- a/src/test/java/com/project/sleep/domain/application/usecase/GetDailyAnalysisUseCaseTest.java
+++ b/src/test/java/com/project/sleep/domain/application/usecase/GetDailyAnalysisUseCaseTest.java
@@ -31,7 +31,7 @@ class GetDailyAnalysisUseCaseTest {
         Long userNo = 100L;
         LocalDate date = LocalDate.of(2025, 9, 22);
         DailyReport mock = DailyReport.builder()
-                .dailyReportId("id-1")
+                .dailyReportNo("id-1")
                 .userNo(userNo)
                 .build();
 
@@ -51,7 +51,7 @@ class GetDailyAnalysisUseCaseTest {
         // Given
         Long userNo = 200L;
         DailyReport mock = DailyReport.builder()
-                .dailyReportId("id-2")
+                .dailyReportNo("id-2")
                 .userNo(userNo)
                 .build();
 

--- a/src/test/java/com/project/sleep/domain/application/usecase/GetSleepGoalUseCaseTest.java
+++ b/src/test/java/com/project/sleep/domain/application/usecase/GetSleepGoalUseCaseTest.java
@@ -1,0 +1,48 @@
+package com.project.sleep.domain.application.usecase;
+
+import com.project.sleep.domain.application.dto.response.SleepGoalResponse;
+import com.project.sleep.domain.domain.entity.SleepGoal;
+import com.project.sleep.domain.domain.service.SleepGoalService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class GetSleepGoalUseCaseTest {
+
+    private SleepGoalService sleepGoalService;
+    private GetSleepGoalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        sleepGoalService = mock(SleepGoalService.class);
+        useCase = new GetSleepGoalUseCase(sleepGoalService);
+    }
+
+    @Test
+    @DisplayName("DB에서 수면 목표를 조회하면 Response로 변환된다")
+    void execute_shouldReturnSleepGoalResponse() {
+        Long userNo = 1L;
+        SleepGoal entity = SleepGoal.builder()
+                .userNo(userNo)
+                .goalBedTime(LocalTime.of(23, 0))
+                .goalWakeTime(LocalTime.of(7, 0))
+                .goalTotalSleepTime(8)
+                .build();
+
+        when(sleepGoalService.findById(userNo)).thenReturn(entity);
+
+        SleepGoalResponse response = useCase.execute(userNo);
+
+        assertThat(response.goalBedTime()).isEqualTo("23:00");
+        assertThat(response.goalWakeTime()).isEqualTo("07:00");
+        assertThat(response.goalTotalSleepTime()).isEqualTo(8);
+
+        verify(sleepGoalService, times(1)).findById(userNo);
+        verifyNoMoreInteractions(sleepGoalService);
+    }
+}

--- a/src/test/java/com/project/sleep/domain/application/usecase/GetSleepPatternsUseCaseTest.java
+++ b/src/test/java/com/project/sleep/domain/application/usecase/GetSleepPatternsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.project.sleep.domain.application.usecase;
 
-import com.project.sleep.domain.application.dto.response.GetSleepPatternsResponse;
+import com.project.sleep.domain.application.dto.response.SleepPatternsResponse;
 import com.project.sleep.domain.domain.entity.DailySleepRecord;
 import com.project.sleep.domain.domain.service.SleepPatternsService;
 import org.junit.jupiter.api.DisplayName;
@@ -49,7 +49,7 @@ class GetSleepPatternsUseCaseTest {
                     .thenReturn(List.of(record));
 
             // When
-            List<GetSleepPatternsResponse> result =
+            List<SleepPatternsResponse> result =
                     getSleepPatternsUseCase.getSleepPatterns(userNo, start, end);
 
             // Then
@@ -74,7 +74,7 @@ class GetSleepPatternsUseCaseTest {
                     .thenReturn(Collections.emptyList());
 
             // When
-            List<GetSleepPatternsResponse> result =
+            List<SleepPatternsResponse> result =
                     getSleepPatternsUseCase.getSleepPatterns(userNo, start, end);
 
             // Then
@@ -129,7 +129,7 @@ class GetSleepPatternsUseCaseTest {
                     .thenReturn(List.of(record));
 
             // When
-            List<GetSleepPatternsResponse> result =
+            List<SleepPatternsResponse> result =
                     getSleepPatternsUseCase.getSleepPatterns(userNo, date, date);
 
             // Then

--- a/src/test/java/com/project/sleep/domain/application/usecase/GetTotalSleepRecordUseCaseTest.java
+++ b/src/test/java/com/project/sleep/domain/application/usecase/GetTotalSleepRecordUseCaseTest.java
@@ -1,0 +1,49 @@
+package com.project.sleep.domain.application.usecase;
+
+import com.project.sleep.domain.application.dto.response.TotalSleepRecordResponse;
+import com.project.sleep.domain.domain.entity.TotalSleepRecord;
+import com.project.sleep.domain.domain.service.TotalSleepRecordService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class GetTotalSleepRecordUseCaseTest {
+
+    private TotalSleepRecordService totalSleepRecordService;
+    private GetTotalSleepRecordUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        totalSleepRecordService = mock(TotalSleepRecordService.class);
+        useCase = new GetTotalSleepRecordUseCase(totalSleepRecordService);
+    }
+
+    @Test
+    @DisplayName("DB에서 총 수면 기록을 조회하면 Response로 변환된다")
+    void execute_shouldReturnTotalSleepRecordResponse() {
+        Long userNo = 1L;
+
+        TotalSleepRecord entity = TotalSleepRecord.builder()
+                .userNo(userNo)
+                .avgScore(85)
+                .avgBedTime(LocalTime.of(23, 0))
+                .avgSleepTime(480)
+                .build();
+
+        when(totalSleepRecordService.findById(userNo)).thenReturn(entity);
+
+        TotalSleepRecordResponse response = useCase.execute(userNo);
+
+        assertThat(response.avgScore()).isEqualTo(85);
+        assertThat(response.avgBedTime()).isEqualTo(LocalTime.of(23, 0));
+        assertThat(response.avgSleepTime()).isEqualTo(480);
+
+        verify(totalSleepRecordService, times(1)).findById(userNo);
+        verifyNoMoreInteractions(totalSleepRecordService);
+    }
+}

--- a/src/test/java/com/project/sleep/domain/application/usecase/SetSleepGoalUseCaseTest.java
+++ b/src/test/java/com/project/sleep/domain/application/usecase/SetSleepGoalUseCaseTest.java
@@ -1,0 +1,57 @@
+package com.project.sleep.domain.application.usecase;
+
+import com.project.sleep.domain.application.dto.request.SleepGoalRequest;
+import com.project.sleep.domain.domain.service.SleepGoalService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class SetSleepGoalUseCaseTest {
+
+    private SleepGoalService sleepGoalService;
+    private SetSleepGoalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        sleepGoalService = mock(SleepGoalService.class);
+        useCase = new SetSleepGoalUseCase(sleepGoalService);
+    }
+
+    @Test
+    @DisplayName("DB에 값X Insert")
+    void execute_shouldInsertWhenDataDoesNotExist() {
+        Long userNo = 1L;
+        SleepGoalRequest request = new SleepGoalRequest(LocalTime.of(23, 0), LocalTime.of(7, 0), 8);
+
+        useCase.execute(userNo, request);
+
+        ArgumentCaptor<Long> userNoCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<SleepGoalRequest> reqCaptor = ArgumentCaptor.forClass(SleepGoalRequest.class);
+        verify(sleepGoalService, times(1)).upsert(userNoCaptor.capture(), reqCaptor.capture());
+        assertThat(userNoCaptor.getValue()).isEqualTo(userNo);
+        assertThat(reqCaptor.getValue()).isEqualTo(request);
+        verifyNoMoreInteractions(sleepGoalService);
+    }
+
+    @Test
+    @DisplayName("DB에 값O Update")
+    void execute_shouldUpdateWhenDataAlreadyExists() {
+        Long userNo = 2L;
+        SleepGoalRequest request = new SleepGoalRequest(LocalTime.of(0, 0), LocalTime.of(8, 0), 9);
+
+        useCase.execute(userNo, request);
+
+        ArgumentCaptor<Long> userNoCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<SleepGoalRequest> reqCaptor = ArgumentCaptor.forClass(SleepGoalRequest.class);
+        verify(sleepGoalService, times(1)).upsert(userNoCaptor.capture(), reqCaptor.capture());
+        assertThat(userNoCaptor.getValue()).isEqualTo(userNo);
+        assertThat(reqCaptor.getValue()).isEqualTo(request);
+        verifyNoMoreInteractions(sleepGoalService);
+    }
+}

--- a/src/test/java/com/project/sleep/domain/domain/service/AnalysisDayServiceTest.java
+++ b/src/test/java/com/project/sleep/domain/domain/service/AnalysisDayServiceTest.java
@@ -42,7 +42,7 @@ class AnalysisDayServiceTest {
         Date expectedKey = Date.from(date.atStartOfDay(ZoneOffset.UTC).toInstant());
 
         DailyReport report = DailyReport.builder()
-                .dailyReportId("id-20250922")
+                .dailyReportNo("id-20250922")
                 .userNo(userNo)
                 .build();
 
@@ -80,7 +80,7 @@ class AnalysisDayServiceTest {
     void getDailyReportWhenDateIsNull() {
         // Given
         DailyReport report = DailyReport.builder()
-                .dailyReportId("id-today")
+                .dailyReportNo("id-today")
                 .userNo(userNo)
                 .build();
 


### PR DESCRIPTION
## 📌 관련 이슈
#24 

## ✨ 변경 사항
- user-service에 있는 기능 sleep-service로 마이그레이션
    - 전체 수면 기록 조회 API
    - 수면 목표 설정 API
    - 수면 목표 조회 API

## ✅ 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 로컬에서 정상 동작 확인
- [x] 관련 테스트 추가/수정 완료
- [x] 문서화 필요 시 업데이트 완료

## 📸 스크린샷 (선택)
- UI 변경이 있는 경우 첨부해주세요.

## 📢 기타 참고 사항
- 리뷰어가 알아야 할 추가 사항을 적어주세요.
